### PR TITLE
watch: Change object type in NewInformer from CustomObject to Secret

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -38,7 +38,7 @@ func FindToken(k8sClient kubernetes.Interface, clusterID string) (string, error)
 
 	_, clusterInformer := cache.NewInformer(
 		listWatch,
-		&CustomObject{},
+		&v1.Secret{},
 		WatchTimeout,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {


### PR DESCRIPTION
Kubeadm token watcher needs to watch for secrets, not for custom objects.